### PR TITLE
Galloping mode added

### DIFF
--- a/InplaceMerge.h
+++ b/InplaceMerge.h
@@ -149,7 +149,7 @@ void sortBlocks(RandomAccessIterator start, int arr_size, int block_len, int n_b
 }
 
 template <class RandomAccessIterator, class Compare>
-void inplaceMerge(Run<RandomAccessIterator> left, Run<RandomAccessIterator> right, Compare comp)
+void inplaceMerge(Run<RandomAccessIterator> left, Run<RandomAccessIterator> right, Compare comp, int gallop = NO_GALLOPING_MODE)
 {
     int arr_size = left.size + right.size;
     int forward_len = static_cast<int>(sqrt(arr_size));
@@ -193,7 +193,7 @@ void inplaceMerge(Run<RandomAccessIterator> left, Run<RandomAccessIterator> righ
         getBlockForward(left.start, i, forward_len, left_block, arr_size);
         getBlockForward(left.start, i + 1, forward_len, right_block, arr_size);
 
-        mergeRunsWithBuffer(left_block, right_block, buffer.start, comp, WM_SWAP_WRITE);
+        mergeRunsWithBuffer(left_block, right_block, buffer.start, comp, WM_SWAP_WRITE, gallop);
     }
 
     RandomAccessIterator finish = right.start + right.size;
@@ -209,7 +209,7 @@ void inplaceMerge(Run<RandomAccessIterator> left, Run<RandomAccessIterator> righ
         getBlockBackward(finish - backward_len, i + 1, backward_len, left_block, arr_size - backward_len);
         getBlockBackward(finish - backward_len, i, backward_len, right_block, arr_size - backward_len);
 
-        mergeRunsWithBuffer(left_block, right_block, finish - backward_len, comp, WM_SWAP_WRITE);
+        mergeRunsWithBuffer(left_block, right_block, finish - backward_len, comp, WM_SWAP_WRITE, gallop);
     }
 
     selectionSort(finish - backward_len, finish, comp, DefaultSwapper<ValueType>());

--- a/Run.h
+++ b/Run.h
@@ -1,6 +1,6 @@
 /*
 Run.h
-Consists o operations working with blocks of data in array called Runs
+Consists of operations working with blocks of data in array called Runs
 1. Offers template class Run
 2. Allows dividing your array into runs using ITimSortParams
 3. Allows merging two runs with usual merge
@@ -86,7 +86,7 @@ void divideArrayToRuns(RandomAccessIterator start, RandomAccessIterator finish,
                        std::vector<Run<RandomAccessIterator>>& runs, const ITimSortParams& params = DEFAULT_PARAMS)
 {
     divideArrayToRuns(start, finish, runs,
-                      std::less_equal<std::iterator_traits<RandomAccessIterator>::value_type>(), params);
+                      std::less<typename std::iterator_traits<RandomAccessIterator>::value_type>(), params);
 }
 
 template <class Type>
@@ -102,21 +102,94 @@ void writeToDestination(Type& dest, Type& src, EWriteMethods write_type)
         dest = src;
 }
 
-template <class RandomAccessIterator, class BufferIterator, class Compare>
-void mergeRunsWithBuffer(Run<RandomAccessIterator> left, Run<RandomAccessIterator> right,
-                         BufferIterator buffer, Compare comp, EWriteMethods write_type = WM_ERASING_WRITE)
+template <class RandomAccessIterator, class Compare>
+int getFollowingLessEqual(RandomAccessIterator& start, int len, RandomAccessIterator& min_value, Compare comp)
+{
+    if (comp(*min_value, *start))
+    {
+        return 0;
+    }
+    //Then left is <=
+    typedef typename std::iterator_traits<RandomAccessIterator>::value_type ValueType;
+    int left = 0, right = 1;
+    while (right < len && !comp(*min_value, *(start + right)))
+    {
+        left = right;
+        right *= 2;
+    }
+    if (right > len)
+        right = len;
+
+    int med = (left + right) / 2;
+    while (right - left > 1)
+    {
+        if (comp(*(start + med), *min_value))
+            left = med;
+        else
+            right = med;
+        med = (left + right) / 2;
+    }
+   
+    return right;
+}
+
+template <class RandomAccessIterator, class Compare>
+void mergeRunsWithBuffer(Run<RandomAccessIterator>& left, Run<RandomAccessIterator>& right,
+                         RandomAccessIterator buffer, Compare comp, EWriteMethods write_type = WM_ERASING_WRITE,
+                         int gallop = NO_GALLOPING_MODE)
 {
     typedef typename std::iterator_traits<RandomAccessIterator>::value_type ValueType;
     for (int i = 0; i < right.start - left.start; i++)
         writeToDestination(buffer[i], left.start[i], write_type);
 
     RandomAccessIterator dest = left.start;
-    BufferIterator left_ptr = buffer;
+    RandomAccessIterator left_ptr = buffer;
     RandomAccessIterator right_ptr = right.start;
+
+    int left_in_row = 0;
+    int right_in_row = 0;
 
     while (left_ptr - buffer < left.size && right_ptr - right.start < right.size)
     {
-        writeToDestination(*(dest++), (comp(*left_ptr, *right_ptr)) ? *(left_ptr++) : *(right_ptr++), write_type);
+        if (comp(*left_ptr, *right_ptr))
+        {
+            writeToDestination(*(dest++), *(left_ptr++), write_type);
+            left_in_row++;
+            right_in_row = 0;
+        }
+        else
+        {
+            writeToDestination(*(dest++), *(right_ptr++), write_type);
+            right_in_row++;
+            left_in_row = 0;
+        }
+         
+        if ((right_in_row >= gallop || left_in_row >= gallop) && gallop != NO_GALLOPING_MODE &&
+            left_ptr - buffer < left.size && right_ptr - right.start < right.size)
+        {
+            RandomAccessIterator* start_gallop = &left_ptr;
+            int n_elems_galloping = 0;
+
+            if (right_in_row >= gallop)
+            {
+                start_gallop = &right_ptr;
+                n_elems_galloping = getFollowingLessEqual(right_ptr, right.size - (right_ptr - right.start),
+                                                          left_ptr, comp);
+                right_in_row = 0;
+            }
+            else
+            {
+                start_gallop = &left_ptr;
+                n_elems_galloping = getFollowingLessEqual(left_ptr, left.size - (left_ptr - buffer),
+                                                          right_ptr, comp);
+                left_in_row = 0;
+            }
+
+            for (int i = 0; i < n_elems_galloping; i++)
+            {
+                writeToDestination(*(dest++), *((*start_gallop)++), write_type);
+            }
+        }
     }
 
     if (left_ptr - buffer == left.size)
@@ -131,22 +204,22 @@ void mergeRunsWithBuffer(Run<RandomAccessIterator> left, Run<RandomAccessIterato
     }
 }
 
-template <class RandomAccessIterator, class Compare>
-void mergeRuns(Run<RandomAccessIterator> left, Run<RandomAccessIterator> right, Compare comp, EWriteMethods write_type = WM_ERASING_WRITE)
+/*template <class RandomAccessIterator, class Compare>
+void mergeRuns(Run<RandomAccessIterator> left, Run<RandomAccessIterator> right, Compare comp, EWriteMethods write_type = WM_ERASING_WRITE, int gallop = NO_GALLOPING_MODE)
 {
     typedef typename std::iterator_traits<RandomAccessIterator>::value_type ValueType;
     ValueType* buf = new ValueType[right.start - left.start];
     for (int i = 0; i < right.start - left.start; i++)
         buf[i] = left.start[i];
 
-    mergeRunsWithBuffer(left, right, buf, comp, write_type);
+    mergeRunsWithBuffer(left, right, buf, comp, write_type, gallop);
 
     delete[] buf;
 }
 
 template <class RandomAccessIterator>
-void mergeRuns(Run<RandomAccessIterator> left, Run<RandomAccessIterator> right, EWriteMethods write_type = WM_ERASING_WRITE)
+void mergeRuns(Run<RandomAccessIterator> left, Run<RandomAccessIterator> right, EWriteMethods write_type = WM_ERASING_WRITE, int gallop = NO_GALLOPING_MODE)
 {
     mergeRuns(left, right, std::less_equal<typename std::iterator_traits<RandomAccessIterator>::value_type>(),
-              write_type);
-}   
+              write_type, gallop);
+}*/   

--- a/TimSort.h
+++ b/TimSort.h
@@ -56,7 +56,7 @@ void insertionSort(RandomAccessIterator start, RandomAccessIterator finish, Comp
 template <class RandomAccessIterator>
 void insertionSort(RandomAccessIterator start, RandomAccessIterator finish)
 {
-    insertionSort(start, finish, std::less_equal<std::iterator_traits<RandomAccessIterator>::value_type>());
+    insertionSort(start, finish, std::less<std::iterator_traits<RandomAccessIterator>::value_type>());
 }
 
 template <class Run>
@@ -67,9 +67,9 @@ void popTo(stack<Run>& runs, Run& x)
 }
 
 template <class Run, class Compare>
-void replaceWithMerged(stack<Run>& runs, Run& left, Run& right, Compare comp)
+void replaceWithMerged(stack<Run>& runs, Run& left, Run& right, Compare comp, int gallop)
 {
-    inplaceMerge(left, right, comp);
+    inplaceMerge(left, right, comp, gallop);
     left.size += right.size;
     runs.push(left);
 }
@@ -82,6 +82,8 @@ void timSort(RandomAccessIterator start, RandomAccessIterator finish,
     divideArrayToRuns(start, finish, runs, comp, params);
     if (runs.size() < 2)
         return;
+
+    //cout << "NRuns: " << runs.size() << "\n";
 
     stack<Run<RandomAccessIterator>> run_stack;
     run_stack.push(runs[0]);
@@ -101,13 +103,13 @@ void timSort(RandomAccessIterator start, RandomAccessIterator finish,
             switch (merge_type)
             {
                 case WM_MERGE_XY:
-                    inplaceMerge(y, x, comp);
+                    inplaceMerge(y, x, comp, params.getGallop());
                     y.size += x.size;
                     x = y;
                     y = z;
                     break;
                 case WM_MERGE_YZ:
-                    inplaceMerge(z, y, comp);
+                    inplaceMerge(z, y, comp, params.getGallop());
                     z.size += y.size;
                     y = z;
                     break;
@@ -121,7 +123,7 @@ void timSort(RandomAccessIterator start, RandomAccessIterator finish,
         }
 
         if (params.needMerge(x.size, y.size))
-            replaceWithMerged(run_stack, y, x, comp);
+            replaceWithMerged(run_stack, y, x, comp, params.getGallop());
         else
         {
             run_stack.push(y);
@@ -134,7 +136,7 @@ void timSort(RandomAccessIterator start, RandomAccessIterator finish,
         Run<RandomAccessIterator> x, y;
         popTo(run_stack, x);
         popTo(run_stack, y);
-        replaceWithMerged(run_stack, y, x, comp);
+        replaceWithMerged(run_stack, y, x, comp, params.getGallop());
     }
 }
 
@@ -143,5 +145,5 @@ void timSort(RandomAccessIterator start, RandomAccessIterator finish,
              const ITimSortParams& params = DEFAULT_PARAMS)
 {
     timSort(start, finish, 
-            std::less_equal<typename std::iterator_traits<RandomAccessIterator>::value_type>(), params);
+            std::less<typename std::iterator_traits<RandomAccessIterator>::value_type>(), params);
 }

--- a/TimSortParams.h
+++ b/TimSortParams.h
@@ -39,7 +39,6 @@ public:
             n /= 2;
         }
         return n + flag;
-        //return 2;
     }
 
     virtual bool needMerge(int len_x, int len_y) const
@@ -63,7 +62,7 @@ public:
 
     virtual int getGallop() const
     {
-        return NO_GALLOPING_MODE;
+        return 7;
     }
 };
 


### PR DESCRIPTION
Galloping mode added
All default comparators made std::less
Dropped usual merge because binary search needs the same types of
iterator while default buffer is ValueType* always